### PR TITLE
add support for lazy loading of maps

### DIFF
--- a/client.go
+++ b/client.go
@@ -303,6 +303,18 @@ func (clnt *Client) Get(policy *BasePolicy, key *Key, binNames ...string) (*Reco
 	return command.GetRecord(), nil
 }
 
+// Like Get but does not deserialize bins containing a map
+func (clnt *Client) GetLazy(policy *BasePolicy, key *Key, binNames ...string) (*Record, error) {
+	policy = clnt.getUsablePolicy(policy)
+
+	command := newReadCommand(clnt.cluster, policy, key, binNames)
+	command.lazy = true
+	if err := command.Execute(); err != nil {
+		return nil, err
+	}
+	return command.GetRecord(), nil
+}
+
 // GetHeader reads a record generation and expiration only for specified key.
 // Bins are not read.
 // The policy can be used to specify timeouts.

--- a/read_command.go
+++ b/read_command.go
@@ -148,10 +148,6 @@ func (cmd *readCommand) handleUdfError(resultCode ResultCode) error {
 	return NewAerospikeError(resultCode)
 }
 
-type lazyMapUnpacker struct {
-	*unpacker
-}
-
 func (cmd *readCommand) parseRecord(
 	ifc command,
 	opCount int,
@@ -195,7 +191,7 @@ func (cmd *readCommand) parseRecord(
 			// we need to make a copy as the buffer is reused
 			b := make([]byte, particleBytesSize)
 			copy(b, cmd.dataBuffer[receiveOffset:receiveOffset+particleBytesSize])
-			value = &lazyMapUnpacker{newUnpacker(b, 0, particleBytesSize)}
+			value = newUnpacker(b, 0, particleBytesSize)
 		} else {
 			value, _ = bytesToParticle(particleType, cmd.dataBuffer, receiveOffset, particleBytesSize)
 		}

--- a/read_command.go
+++ b/read_command.go
@@ -17,6 +17,7 @@ package aerospike
 import (
 	"reflect"
 
+	ParticleType "github.com/aerospike/aerospike-client-go/internal/particle_type"
 	. "github.com/aerospike/aerospike-client-go/logger"
 
 	. "github.com/aerospike/aerospike-client-go/types"
@@ -34,6 +35,7 @@ type readCommand struct {
 	object *reflect.Value
 
 	replicaSequence int
+	lazy            bool
 }
 
 // this method uses reflection.
@@ -146,6 +148,10 @@ func (cmd *readCommand) handleUdfError(resultCode ResultCode) error {
 	return NewAerospikeError(resultCode)
 }
 
+type lazyMapUnpacker struct {
+	*unpacker
+}
+
 func (cmd *readCommand) parseRecord(
 	ifc command,
 	opCount int,
@@ -184,7 +190,15 @@ func (cmd *readCommand) parseRecord(
 		receiveOffset += 4 + 4 + nameSize
 
 		particleBytesSize := opSize - (4 + nameSize)
-		value, _ := bytesToParticle(particleType, cmd.dataBuffer, receiveOffset, particleBytesSize)
+		var value interface{}
+		if cmd.lazy && particleType == ParticleType.MAP {
+			// we need to make a copy as the buffer is reused
+			b := make([]byte, particleBytesSize)
+			copy(b, cmd.dataBuffer[receiveOffset:receiveOffset+particleBytesSize])
+			value = &lazyMapUnpacker{newUnpacker(b, 0, particleBytesSize)}
+		} else {
+			value, _ = bytesToParticle(particleType, cmd.dataBuffer, receiveOffset, particleBytesSize)
+		}
 		receiveOffset += particleBytesSize
 
 		if bins == nil {


### PR DESCRIPTION
Add flag to read command do disable map decoding. Instead an unpacker object with a copy of the msgpack buffer is returned. The user can defined an interface that offers `unpacker` methods and check bin values against it to see if the values are not yet decoded, and decode them on demand. 