### PR TITLE
Correctly set an error when the node is unavailable during the execution of the command.

### DIFF
--- a/command.go
+++ b/command.go
@@ -1717,6 +1717,9 @@ func (cmd *baseCommand) execute(ifc command, isRead bool) error {
 		// set command node, so when you return a record it has the node
 		cmd.node, err = ifc.getNode(ifc)
 		if cmd.node == nil || !cmd.node.IsActive() || err != nil {
+			if err == nil {
+				err = NewAerospikeError(INVALID_NODE_ERROR, "Node not found for partition or not active")
+			}
 			// Node is currently inactive. Retry.
 			continue
 		}

--- a/command.go
+++ b/command.go
@@ -1718,7 +1718,7 @@ func (cmd *baseCommand) execute(ifc command, isRead bool) error {
 		cmd.node, err = ifc.getNode(ifc)
 		if cmd.node == nil || !cmd.node.IsActive() || err != nil {
 			if err == nil {
-				err = NewAerospikeError(INVALID_NODE_ERROR, "Node not found for partition or not active")
+				err = NewAerospikeError(INVALID_NODE_ERROR, "Node not found/not active for partition")
 			}
 			// Node is currently inactive. Retry.
 			continue


### PR DESCRIPTION
There may be a problem when the node on which the command should be executed is selected, but soon after that, it becomes unavailable. In this case, if the policy requires an exit due to the maximum number of retries, the client will return nil instead of an error, even if the record was not retrieved and parsed.

[fix panic in bidder caused by loadIdfvHistory nil pointer](https://trello.com/c/pbuGCyYW/5250-fix-panic-in-bidder-caused-by-loadidfvhistory-nil-pointer)